### PR TITLE
Cargo: fix links for Blightmud org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ description = "low-level Telnet protocol implementation for MUD clients"
 version = "2.0.1"
 edition = "2018"
 readme = "README.md"
-homepage = "https://github.com/cpu/libmudtelnet"
-repository = "https://github.com/cpu/libmudtelnet"
+homepage = "https://github.com/blightmud/libmudtelnet"
+repository = "https://github.com/blightmud/libmudtelnet"
 documentation = "https://docs.rs/libmudtelnet"
 license = "MIT"
 keywords = ["telnet", "libtelnet", "mud"]
@@ -24,4 +24,7 @@ default = ["std"]
 std = []
 
 [patch.crates-io]
+# We use a fork of libtelnet-rs that has a few patches applied to it to fix bugs also fixed in this repo. If we use
+# the vanilla upstream 2.0.0 release our fuzzing/interop testing will fail when we encounter input that tickles
+# these unfixed bugs.
 libtelnet-rs = { git = "https://github.com/cpu/libtelnet-rs", branch = "cpu-libmudtelnet-compat" }

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Many thanks to:
 * [envis10n] for his work on [libtelnet-rs], which `libmudtelnet` is forked from.
 * [Sean Middleditch] for his work on [libtelnet], which inspired `libtelent-rs`.
 
-[github-actions-badge]: https://img.shields.io/github/actions/workflow/status/cpu/libmudtelnet/rust.yml?label=build%20%26%20tests&logo=github&style=for-the-badge&branch=main
-[github-actions-link]: https://github.com/cpu/libmudtelnet/actions/workflows/rust.yml?query=branch%3Amain
+[github-actions-badge]: https://img.shields.io/github/actions/workflow/status/blightmud/libmudtelnet/rust.yml?label=build%20%26%20tests&logo=github&style=for-the-badge&branch=main
+[github-actions-link]: https://github.com/blightmud/libmudtelnet/actions/workflows/rust.yml?query=branch%3Amain
 [crate-badge]: https://img.shields.io/crates/v/libmudtelnet.svg?style=for-the-badge
 [crate-link]: https://crates.io/crates/libmudtelnet
 [docs-badge]: https://img.shields.io/badge/docs-rs-blue.svg?style=for-the-badge


### PR DESCRIPTION
This repo was moved from my own user to the Blightmud org. This commit fixes up stale references and adds a comment about the crates-io patch.